### PR TITLE
Fix nvim-treesitter parser config `install_info` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Please note that both the WebGPU and WGSL spec are still under development.
    parser_config.wgsl = {
        install_info = {
            url = "https://github.com/szebniok/tree-sitter-wgsl",
-           files = {"src/parser.c"}
+           files = {"src/parser.c", "src/scanner.c"}
        },
    }
    


### PR DESCRIPTION

I forgot to update the `files` field in the README.md manual install instructions to include the new `scanner.c` source file that was added in #7. Without it nvim-treesitter fails to compile the parser. #8

Though maybe It'd be better to just replace these instructions with something simpler. The grammar is already included in nvim-treesitter's repo already, so there isn't a need to manually add it to the parser config or symlink query files.


