### PR TITLE
Do not override @type highlights with @variable

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,6 +1,7 @@
 (int_literal) @number
 (float_literal) @float
 (bool_literal) @boolean
+(identifier) @variable
 
 (type_declaration [ "bool" "u32" "i32" "f16" "f32" ] @type.builtin)
 (type_declaration) @type
@@ -19,8 +20,6 @@
 
 (attribute
     (identifier) @attribute)
-
-(identifier) @variable
 
 (type_constructor_or_function_call_expression
     (type_declaration) @function.call)


### PR DESCRIPTION
Hi! This is my first time working with grammar files, this seems to work however. I moved the `@variable` rule higher than `@type` so that `@type` takes precedence over it.

Should fix #11.